### PR TITLE
Changed export content type to Buffer

### DIFF
--- a/index.js
+++ b/index.js
@@ -47,8 +47,7 @@ var excelTables = function(config) {
       var qry = makeQry(config.folder, file.table, file.select, file.additional);
       alasql(qry,[],function(data){
         var strTbl = makeArray(data);
-        file.contents += '\n\n' + strTbl;
-        //console.log(file.contents);
+        file.contents = Buffer.concat([file.contents, Buffer.from('\n\n' + strTbl)]);
         alldone();
       });
     };

--- a/index.js
+++ b/index.js
@@ -35,7 +35,6 @@ var excelTables = function(config) {
     var alldone = (function (){
         var count = 0;
         return function alldone() {
-          console.log(count);
           if (++count >= filenames.length) {
             done();
           }

--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
   "author": "Patrick Moore",
   "license": "MIT",
   "dependencies": {
-    "alasql": "^0.2.0",
+    "alasql": "^0.3.0",
     "lodash": "^3.10.1",
     "markdown-table": "^0.4.0"
   }


### PR DESCRIPTION
Not a big change, but fixes issues with chaining multiple plugins that don't smoothly handle non-buffer content values.